### PR TITLE
Fix mapping code and interval settings

### DIFF
--- a/models/Ota_model.php
+++ b/models/Ota_model.php
@@ -292,7 +292,7 @@ class Ota_model extends App_Model
     private function get_mapping_by_code($product_code, $channel_id)
     {
         if (empty($product_code) || empty($channel_id)) { return null; }
-        $this->db->where('TRIM(ota_product_code)', trim($product_code));
+        $this->db->where('TRIM(ota_product_code)', trim($product_code), false);
         $this->db->where('channel_id', $channel_id);
         return $this->db->get('tbl_ota_product_mappings')->row();
     }

--- a/views/bookings/manage.php
+++ b/views/bookings/manage.php
@@ -104,6 +104,6 @@ init_head(); ?>
         }
 
         // Bắt đầu kiểm tra định kỳ mỗi 20 giây (20000 mili giây)
-        setInterval(fetchNewBookings, 2000);
+        setInterval(fetchNewBookings, 20000);
     });
 </script>

--- a/views/products/manage.php
+++ b/views/products/manage.php
@@ -76,7 +76,7 @@
 <script>
     $(function(){
         // Khởi tạo bảng
-        initDataTable('.table-product-mappings', window.location.href, undefined, undefined, 'undefined');
+        initDataTable('.table-product-mappings', window.location.href, undefined, undefined, undefined);
 
         // SỬA LỖI: Thêm validator cho form để đảm bảo dữ liệu hợp lệ trước khi gửi
         appValidateForm($('#mapping-form'), {


### PR DESCRIPTION
## Summary
- Use correct undefined value when initializing product mappings table
- Trim OTA product codes without escaping to match correctly
- Align booking refresh interval with documented 20 seconds

## Testing
- `php -l models/Ota_model.php`
- `php -l views/bookings/manage.php`
- `php -l views/products/manage.php`


------
https://chatgpt.com/codex/tasks/task_e_68b84d486b7483248b08a1635aa60acc